### PR TITLE
fixed crashes when midi is used anywhere else in the app

### DIFF
--- a/launchpad.js
+++ b/launchpad.js
@@ -16,13 +16,11 @@ var Launchpad = function(port, initAnimation, midiInput, midiOutput) {
 	if (midiInput === undefined) {
 		this.input = new midi.input();
 	} else {
-		console.log("using supplied input");
 		this.input = midiInput;
 	}
 	if (midiOutput === undefined) {
 		this.output = new midi.output();
 	} else {
-		console.log("using supplied output");
 		this.output = midiOutput;
 	}
 	


### PR DESCRIPTION
Dear sydlawrence,

I find your midi-launchpad package awesome, except for one thing: node.js mysteriously crashed more ofter than not when trying to use midi for other purposes as well in the app. (I am using OS X Mavericks)
Being able to supply my own instance of midi.input and midi.output solves the problem.
I ask you to accept this pull request.

Cheers,
Zsolt
