### PR TITLE
Fix scrollBytes when used with multiple devices

### DIFF
--- a/launchpad.js
+++ b/launchpad.js
@@ -296,6 +296,7 @@ Launchpad.prototype.clearScroll = function() {
 Launchpad.prototype.scrollBytes = function(bytes, delay, color, onFinished) {
     var perScreen = 8;
     var charPos = 0;
+    var interval = 0;
     var overallBytes = [];
     for (var i= 0; i < bytes[0].length; i++) {
         var toAdd = "";


### PR DESCRIPTION
This fixes a bug in the ```scrollBytes``` method.  The ```interval``` variable used was not locally declared, so when multiple pads are in use and simultaneously scrolling text - the first to complete stops all messages.